### PR TITLE
Use enum for SoundEffects instead of Strings

### DIFF
--- a/src/main/java/net/liquidpineapple/pang/AudioSystem.java
+++ b/src/main/java/net/liquidpineapple/pang/AudioSystem.java
@@ -95,20 +95,21 @@ public class AudioSystem {
   /**
    * Method to play a soundeffect.
    *
-   * @param path - path to the effect.
+   * @param soundEffect The {@link SoundEffect} you want to play
    */
-  public static void playEffect(String path) {
-    playEffect(path, true, 1);
+  public static void playEffect(SoundEffect soundEffect) {
+    playEffect(soundEffect, true, 1);
   }
 
   /**
    * Plays a sound effect.
    *
-   * @param name         The name of the sound file you want to play
+   * @param soundEffect  The {@link SoundEffect} you want to play
    * @param allowOverlap Decides if this sound can play while the same sound is already playing
-   * @param numSounds    The number of different versions of this sound effect to choose from.
+   * @param numSounds    The number of different versions of  this sound effect to choose from.
    */
-  public static void playEffect(String name, boolean allowOverlap, int numSounds) {
+  public static void playEffect(SoundEffect soundEffect, boolean allowOverlap, int numSounds) {
+    String name = soundEffect.getName();
     if (!allowOverlap && effectsPlaying.contains(name)) {
       return;
     }

--- a/src/main/java/net/liquidpineapple/pang/SoundEffect.java
+++ b/src/main/java/net/liquidpineapple/pang/SoundEffect.java
@@ -1,0 +1,27 @@
+package net.liquidpineapple.pang;
+
+import lombok.Getter;
+
+/**
+ * @author Govert de Gans
+ * @date 2016-10-25
+ */
+public final class SoundEffect {
+  public static final SoundEffect COLLECT_COIN = new SoundEffect("coin");
+  public static final SoundEffect COLLECT_BOMB = new SoundEffect("genericPowerup");
+  public static final SoundEffect COLLECT_FREEZE = new SoundEffect("genericPowerup");
+  public static final SoundEffect COLLECT_HEART = new SoundEffect("genericPowerup");
+  public static final SoundEffect COLLECT_HOOK = new SoundEffect("genericPowerup");
+  public static final SoundEffect COLLECT_SHIELD = new SoundEffect("shield");
+  public static final SoundEffect COLLECT_STICKY = new SoundEffect("genericPowerup");
+  public static final SoundEffect FOOTSTEP = new SoundEffect("step");
+  public static final SoundEffect HOOK_SHOOT = new SoundEffect("lazor");
+  public static final SoundEffect PLAYER_HIT = new SoundEffect("hit");
+  public static final SoundEffect BALL_DESTROY = new SoundEffect("pop");
+
+  @Getter
+  private String name;
+  private SoundEffect(String name) {
+    this.name = name;
+  }
+}

--- a/src/main/java/net/liquidpineapple/pang/SoundEffect.java
+++ b/src/main/java/net/liquidpineapple/pang/SoundEffect.java
@@ -1,7 +1,5 @@
 package net.liquidpineapple.pang;
 
-import lombok.Getter;
-
 /**
  * @author Govert de Gans
  * @date 2016-10-25
@@ -19,9 +17,13 @@ public final class SoundEffect {
   public static final SoundEffect PLAYER_HIT = new SoundEffect("hit");
   public static final SoundEffect BALL_DESTROY = new SoundEffect("pop");
 
-  @Getter
   private String name;
+
   private SoundEffect(String name) {
     this.name = name;
+  }
+
+  public String getName() {
+    return this.name;
   }
 }

--- a/src/main/java/net/liquidpineapple/pang/objects/Ball.java
+++ b/src/main/java/net/liquidpineapple/pang/objects/Ball.java
@@ -5,6 +5,7 @@ import lombok.EqualsAndHashCode;
 
 import net.liquidpineapple.pang.Application;
 import net.liquidpineapple.pang.AudioSystem;
+import net.liquidpineapple.pang.SoundEffect;
 import net.liquidpineapple.pang.gui.ScoreSystem;
 import net.liquidpineapple.pang.logger.Logger;
 
@@ -146,7 +147,7 @@ public class Ball extends GameObject {
         + (this.getHeight() / 2));
     //remove ball
     Logger.info("Removing " + this);
-    AudioSystem.playEffect("pop");
+    AudioSystem.playEffect(SoundEffect.BALL_DESTROY);
     Application.getBoard().getCurrentScreen().objectList.remove(this);
   }
 

--- a/src/main/java/net/liquidpineapple/pang/objects/Drop.java
+++ b/src/main/java/net/liquidpineapple/pang/objects/Drop.java
@@ -2,6 +2,7 @@ package net.liquidpineapple.pang.objects;
 
 import net.liquidpineapple.pang.Application;
 import net.liquidpineapple.pang.AudioSystem;
+import net.liquidpineapple.pang.SoundEffect;
 import net.liquidpineapple.pang.gui.ScoreSystem;
 
 /**
@@ -13,7 +14,7 @@ public class Drop extends GameObject {
   private int score;
   private double movY;
   private double movX;
-  protected String collectSound;
+  protected SoundEffect collectSound;
 
   /**
    * Method that creates a new drop.
@@ -29,7 +30,7 @@ public class Drop extends GameObject {
               int score) {
     super(textureLocation, startX, startY);
     this.score = score;
-    this.collectSound = "coin";
+    this.collectSound = SoundEffect.COLLECT_COIN;
     this.movY = movY;
     this.movX = movX;
   }

--- a/src/main/java/net/liquidpineapple/pang/objects/Player.java
+++ b/src/main/java/net/liquidpineapple/pang/objects/Player.java
@@ -5,6 +5,7 @@ import lombok.EqualsAndHashCode;
 
 import net.liquidpineapple.pang.Application;
 import net.liquidpineapple.pang.AudioSystem;
+import net.liquidpineapple.pang.SoundEffect;
 import net.liquidpineapple.pang.gui.LifeSystem;
 import net.liquidpineapple.pang.gui.TimeSystem;
 import net.liquidpineapple.pang.logger.Logger;
@@ -57,7 +58,7 @@ public class Player extends GameObject {
     int boardWidth = Application.getBoard().getWidth();
     double playerMaxPosX = boardWidth - this.getWidth();
     xpos = Math.min(xpos, playerMaxPosX);
-    AudioSystem.playEffect("step", false, 3);
+    AudioSystem.playEffect(SoundEffect.FOOTSTEP, false, 3);
   }
 
   @Override
@@ -92,7 +93,7 @@ public class Player extends GameObject {
     if (playerScheme.shootPressed() && !shootheld && activeHooks < maximumHooks) {
       HookAndRope newRope = new HookAndRope(getXpos(), 0, this, hookRemoveDelay);
       Application.getBoard().getCurrentScreen().objectList.add(newRope);
-      AudioSystem.playEffect("lazor");
+      AudioSystem.playEffect(SoundEffect.HOOK_SHOOT);
       activeHooks++;
       shootheld = true;
     }
@@ -110,7 +111,7 @@ public class Player extends GameObject {
         LifeSystem.loseLife();
       }
       isHit = true;
-      AudioSystem.playEffect("hit");
+      AudioSystem.playEffect(SoundEffect.PLAYER_HIT);
     }
   }
 

--- a/src/main/java/net/liquidpineapple/pang/objects/powerups/BombDrop.java
+++ b/src/main/java/net/liquidpineapple/pang/objects/powerups/BombDrop.java
@@ -1,6 +1,7 @@
 package net.liquidpineapple.pang.objects.powerups;
 
 import net.liquidpineapple.pang.Application;
+import net.liquidpineapple.pang.SoundEffect;
 import net.liquidpineapple.pang.objects.Ball;
 import net.liquidpineapple.pang.objects.Drop;
 import net.liquidpineapple.pang.objects.GameObject;
@@ -16,7 +17,7 @@ public class BombDrop extends Drop {
   public BombDrop(String textureLocation, double startX, double startY, double movX, double movY,
                   int score) {
     super(textureLocation, startX, startY, movX, movY, score);
-    this.collectSound = "genericPowerup";
+    this.collectSound = SoundEffect.COLLECT_BOMB;
   }
 
 

--- a/src/main/java/net/liquidpineapple/pang/objects/powerups/FreezeTimeDrop.java
+++ b/src/main/java/net/liquidpineapple/pang/objects/powerups/FreezeTimeDrop.java
@@ -1,5 +1,6 @@
 package net.liquidpineapple.pang.objects.powerups;
 
+import net.liquidpineapple.pang.SoundEffect;
 import net.liquidpineapple.pang.gui.TimeSystem;
 import net.liquidpineapple.pang.objects.Drop;
 import net.liquidpineapple.pang.objects.Player;
@@ -18,7 +19,7 @@ public class FreezeTimeDrop extends Drop {
   public FreezeTimeDrop(String textureLocation, double startX, double startY, double movX,
                         double movY, int score, int timeFrozen) {
     super(textureLocation, startX, startY, movX, movY, score);
-    this.collectSound = "genericPowerup";
+    this.collectSound = SoundEffect.COLLECT_FREEZE;
     this.timeFrozen = Math.max(timeFrozen ,0);
   }
 

--- a/src/main/java/net/liquidpineapple/pang/objects/powerups/HeartDrop.java
+++ b/src/main/java/net/liquidpineapple/pang/objects/powerups/HeartDrop.java
@@ -1,5 +1,6 @@
 package net.liquidpineapple.pang.objects.powerups;
 
+import net.liquidpineapple.pang.SoundEffect;
 import net.liquidpineapple.pang.gui.LifeSystem;
 import net.liquidpineapple.pang.objects.Drop;
 import net.liquidpineapple.pang.objects.Player;
@@ -17,7 +18,7 @@ public class HeartDrop extends Drop {
   public HeartDrop(String textureLocation, double startX, double startY, double movX, double movY,
                    int score, int livesChange) {
     super(textureLocation, startX, startY, movX, movY, score);
-    this.collectSound = "genericPowerup";
+    this.collectSound = SoundEffect.COLLECT_HEART;
     this.livesChange = livesChange;
   }
 

--- a/src/main/java/net/liquidpineapple/pang/objects/powerups/HookDrop.java
+++ b/src/main/java/net/liquidpineapple/pang/objects/powerups/HookDrop.java
@@ -1,5 +1,6 @@
 package net.liquidpineapple.pang.objects.powerups;
 
+import net.liquidpineapple.pang.SoundEffect;
 import net.liquidpineapple.pang.objects.Drop;
 import net.liquidpineapple.pang.objects.Player;
 
@@ -18,7 +19,7 @@ public class HookDrop extends Drop {
                   int score, int hookChange) {
     super(textureLocation, startX, startY, movX, movY, score);
     this.hookChange = hookChange;
-    this.collectSound = "genericPowerup";
+    this.collectSound = SoundEffect.COLLECT_HOOK;
   }
 
 

--- a/src/main/java/net/liquidpineapple/pang/objects/powerups/ShieldDrop.java
+++ b/src/main/java/net/liquidpineapple/pang/objects/powerups/ShieldDrop.java
@@ -1,5 +1,6 @@
 package net.liquidpineapple.pang.objects.powerups;
 
+import net.liquidpineapple.pang.SoundEffect;
 import net.liquidpineapple.pang.objects.Drop;
 import net.liquidpineapple.pang.objects.Player;
 
@@ -18,7 +19,7 @@ public class ShieldDrop extends Drop {
                     int score, int shield) {
     super(textureLocation, startX, startY, movX, movY, score);
     this.shield = shield;
-    this.collectSound = "shield";
+    this.collectSound = SoundEffect.COLLECT_SHIELD;
   }
 
 

--- a/src/main/java/net/liquidpineapple/pang/objects/powerups/StickyHookDrop.java
+++ b/src/main/java/net/liquidpineapple/pang/objects/powerups/StickyHookDrop.java
@@ -1,5 +1,6 @@
 package net.liquidpineapple.pang.objects.powerups;
 
+import net.liquidpineapple.pang.SoundEffect;
 import net.liquidpineapple.pang.objects.Drop;
 import net.liquidpineapple.pang.objects.Player;
 
@@ -16,7 +17,7 @@ public class StickyHookDrop extends Drop {
   public StickyHookDrop(String textureLocation, double startX, double startY,
                         double movX, double movY, int score, int stickyDelayTime) {
     super(textureLocation, startX, startY, movX, movY, score);
-    this.collectSound = "genericPowerup";
+    this.collectSound = SoundEffect.COLLECT_STICKY;
     this.stickyDelayTime = Math.max(stickyDelayTime, 0);
   }
 


### PR DESCRIPTION
This changes the way AudioSystem.playEffect() is called.
It no longer accepts Strings as effect names, but uses an 'enum' now.
It's technically not a real enum, but this works best in my opinion.
Fixes #157.