### PR TITLE
Bugfix/165

### DIFF
--- a/src/main/java/net/liquidpineapple/pang/XmlHandler.java
+++ b/src/main/java/net/liquidpineapple/pang/XmlHandler.java
@@ -44,9 +44,8 @@ public class XmlHandler {
    * Method which parses a Level into a xml file.
    *
    * @param level - Level to be parsed
-   * @param time  - Time the level may take.
    */
-  public static void createXmlFromLevel(LevelScreen level, int time) {
+  public static void createXmlFromLevel(LevelScreen level) {
     try {
       DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
       DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
@@ -78,7 +77,7 @@ public class XmlHandler {
 
       //time element
       Element timeElement = doc.createElement("time");
-      timeElement.appendChild(doc.createTextNode(Integer.toString(time)));
+      timeElement.appendChild(doc.createTextNode(Integer.toString(level.getTime())));
       objects.appendChild(timeElement);
 
       // write the content into xml file

--- a/src/main/java/net/liquidpineapple/pang/XmlHandler.java
+++ b/src/main/java/net/liquidpineapple/pang/XmlHandler.java
@@ -179,7 +179,8 @@ public class XmlHandler {
       for (Player player : loadPlayer(doc.getElementsByTagName("player"))) {
         output.objectList.add(player);
       }
-      loadTime(doc);
+
+      output.setTime(loadTime(doc));
       TimeSystem.resetTime(loadTime(doc));
 
       for (NumberToken token : TimeSystem.getTimePlaces()) {

--- a/src/main/java/net/liquidpineapple/pang/screens/LevelEditor.java
+++ b/src/main/java/net/liquidpineapple/pang/screens/LevelEditor.java
@@ -29,7 +29,7 @@ import javax.imageio.ImageIO;
  * @date 10-10-2016.
  */
 public class LevelEditor extends Screen {
-  private static final int gametime = 120;
+  private static final int LEVELTIME = 120;
   public LinkedList<GameObject> addedObjects = new LinkedList<>();
   private boolean addedPlayer = false;
   private int currentMouseX = 0;
@@ -192,9 +192,10 @@ public class LevelEditor extends Screen {
   public void createLevel() {
 
     LevelScreen level = new LevelScreen();
+    level.setTime(LEVELTIME);
     level.objectList = addedObjects;
 
-    XmlHandler.createXmlFromLevel(level, gametime);
+    XmlHandler.createXmlFromLevel(level);
   }
 
   /**

--- a/src/main/java/net/liquidpineapple/pang/screens/LevelScreen.java
+++ b/src/main/java/net/liquidpineapple/pang/screens/LevelScreen.java
@@ -1,6 +1,7 @@
 package net.liquidpineapple.pang.screens;
 
 import lombok.Getter;
+import lombok.Setter;
 
 import net.liquidpineapple.pang.Application;
 import net.liquidpineapple.pang.gui.Board;
@@ -29,10 +30,17 @@ public class LevelScreen extends Screen {
   @Getter
   private LinkedList<GameObject> hudObjectList;
 
+  @Getter
+  @Setter
+  private int time;
+
+  private static final int DEFAULT_TIME = 120;
+
 
   public LevelScreen() {
     super();
     hudObjectList = new LinkedList<GameObject>();
+    time = DEFAULT_TIME;
   }
 
   @Override
@@ -66,15 +74,18 @@ public class LevelScreen extends Screen {
    */
   private void nextLevel() throws ParserConfigurationException, SAXException {
     Board currentBoard = Application.getBoard();
-    Screen newScreen;
+
 
     if (currentBoard.getLevels().hasNext()) {
-      newScreen = (Screen) currentBoard.getLevels().next();
+      LevelScreen newScreen = (LevelScreen) currentBoard.getLevels().next();
+      TimeSystem.resetTime(newScreen.getTime());
+      currentBoard.changeScreen(newScreen);
     } else {
       //set behaviour when all levels have been completed here.
-      newScreen = new WinScreen();
+      Screen newScreen = new WinScreen();
+      currentBoard.changeScreen(newScreen);
     }
-    currentBoard.changeScreen(newScreen);
+
   }
 
   @Override

--- a/src/main/java/net/liquidpineapple/pang/screens/LevelScreen.java
+++ b/src/main/java/net/liquidpineapple/pang/screens/LevelScreen.java
@@ -32,11 +32,15 @@ public class LevelScreen extends Screen {
 
   @Getter
   @Setter
+  @SuppressWarnings("PMD.UnusedPrivateField") // It is used in the generated getter method
   private int time;
 
   private static final int DEFAULT_TIME = 120;
 
 
+  /**
+   * Constructor for the LevelScreen class
+   */
   public LevelScreen() {
     super();
     hudObjectList = new LinkedList<GameObject>();


### PR DESCRIPTION
Makes sure the time resets after each completed level.

Most important changes: 
 - Level now has a private field time, containing the time a level may take.
 - XMLHandler now uses this field to write a level to a file, instead of an parameter given to the createXmlFromLevel method
 - XMLHandler now sets the time of a level, instead of reseting the timesystem's time. This supports the preloading of levels

Fixes #165 